### PR TITLE
Libc bin issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,9 @@ ENV PYTHONUNBUFFERED=1 \
 WORKDIR /myapp
 
 # Update system and specifically upgrade libc-bin to the required security patch version
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc \
-    libpq-dev \
-    && apt-get install -y libc-bin=2.36-9+deb12u7 \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gcc libpq-dev \
+    && apt-get install -y --allow-downgrades libc-bin=2.36-9+deb12u7 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -30,7 +29,7 @@ RUN python -m venv /.venv \
 FROM python:3.12-slim-bookworm as final
 
 # Upgrade libc-bin in the final stage to ensure security patch is applied
-RUN apt-get update && apt-get install -y libc-bin=2.36-9+deb12u7 \
+RUN apt-get update && apt-get install -y --allow-downgrades libc-bin=2.36-9+deb12u7 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Define a base stage with a Debian Bookworm base image that includes the latest glibc update
+# Define a base stage with a Debian Bookworm base image
 FROM python:3.12-bookworm as base
 
 # Set environment variables
@@ -11,10 +11,9 @@ ENV PYTHONUNBUFFERED=1 \
 
 WORKDIR /myapp
 
-# Update system and specifically upgrade libc-bin to the required security patch version
+# Update system and install required dependencies without forcing libc-bin version
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends gcc libpq-dev \
-    && apt-get install -y --allow-downgrades libc-bin=2.36-9+deb12u7 \
+    && apt-get install -y --no-install-recommends gcc libpq-dev libc-bin \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -25,18 +24,19 @@ RUN python -m venv /.venv \
     && pip install --upgrade pip \
     && pip install -r requirements.txt
 
-# Define a second stage for the runtime, using the same Debian Bookworm slim image
+# Define a second stage for the runtime
 FROM python:3.12-slim-bookworm as final
 
-# Upgrade libc-bin in the final stage to ensure security patch is applied
-RUN apt-get update && apt-get install -y --allow-downgrades libc-bin=2.36-9+deb12u7 \
+# Update system libraries without forcing libc-bin version
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libc-bin \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the virtual environment from the base stage
 COPY --from=base /.venv /.venv
 
-# Set environment variable to ensure all python commands run inside the virtual environment
+# Set environment variables
 ENV PATH="/.venv/bin:$PATH" \
     PYTHONUNBUFFERED=1 \
     PYTHONFAULTHANDLER=1 \
@@ -52,8 +52,8 @@ USER myuser
 # Copy application code with appropriate ownership
 COPY --chown=myuser:myuser . .
 
-# Inform Docker that the container listens on the specified port at runtime.
+# Expose application port
 EXPOSE 8000
 
-# Use ENTRYPOINT to specify the executable when the container starts.
+# Entry point to run the application
 ENTRYPOINT ["uvicorn", "app.main:app", "--reload", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Removed the forced installation of libc-bin=2.36-9+deb12u7 and allowed the latest compatible version to be installed from the default repositories.
Added --no-install-recommends to minimize unnecessary dependencies during installation.
Ensured system libraries are updated in both build and runtime stages.