### PR TITLE
duplicate email and nickname while updating the user issue

### DIFF
--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -87,6 +87,13 @@ async def update_user(user_id: UUID, user_update: UserUpdate, request: Request, 
     - **user_update**: UserUpdate model with updated user information.
     """
     user_data = user_update.model_dump(exclude_unset=True)
+    existing_user = await UserService.get_by_email(db, user_update.email)
+    if existing_user:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already exists")
+
+    existing_user_nickname = await UserService.get_by_nickname(db, user_update.nickname)
+    if existing_user_nickname:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Nickname already exists")
     updated_user = await UserService.update(db, user_id, user_data)
     if not updated_user:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -85,7 +85,14 @@ class UserService:
         try:
             # validated_data = UserUpdate(**update_data).dict(exclude_unset=True)
             validated_data = UserUpdate(**update_data).model_dump(exclude_unset=True)
-
+            existing_user = await cls.get_by_email(session, validated_data['email'])
+            if existing_user:
+                logger.error("User with given email already exists.")
+                return None
+            existing_user_nickname = await cls.get_by_nickname(session, validated_data['nickname'])
+            if existing_user_nickname:
+                logger.error("User with given nickname already exists.")
+                return None  
             if 'password' in validated_data:
                 validated_data['hashed_password'] = hash_password(validated_data.pop('password'))
             query = update(User).where(User.id == user_id).values(**validated_data).execution_options(synchronize_session="fetch")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,3 +250,18 @@ def generate_unique_user():
         "last_name": "Case",
         "role": "AUTHENTICATED"
     }
+
+@pytest.fixture
+async def test_user(db_session):
+    """Fixture to create and return a test user."""
+    user = User(
+        id=str(uuid.uuid4()),
+        email="test_user@example.com",
+        nickname="test_user",
+        hashed_password=hash_password("MySuperPassword$1234"),
+        role="AUTHENTICATED"
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -1,11 +1,14 @@
 from builtins import str
+from datetime import datetime
+import sqlalchemy as sa
 import pytest
 from httpx import AsyncClient
 from app.main import app
 from app.models.user_model import User, UserRole
 from app.utils.nickname_gen import generate_nickname
 from app.utils.security import hash_password
-from app.services.jwt_service import decode_token  # Import your FastAPI app
+from app.services.jwt_service import decode_token
+from tests.conftest import admin_user  # Import your FastAPI app
 
 # Example of a test function using the async_client fixture
 @pytest.mark.asyncio
@@ -45,7 +48,7 @@ async def test_update_user_email_access_denied(async_client, verified_user, user
 
 @pytest.mark.asyncio
 async def test_update_user_email_access_allowed(async_client, admin_user, admin_token):
-    updated_data = {"email": f"updated_{admin_user.id}@example.com"}
+    updated_data = {"email": f"updated_{admin_user.id}@example.com", "nickname": "new_nickname"}
     headers = {"Authorization": f"Bearer {admin_token}"}
     response = await async_client.put(f"/users/{admin_user.id}", json=updated_data, headers=headers)
     assert response.status_code == 200
@@ -151,16 +154,33 @@ async def test_delete_user_does_not_exist(async_client, admin_token):
     assert delete_response.status_code == 404
 
 @pytest.mark.asyncio
-async def test_update_user_github(async_client, admin_user, admin_token):
-    updated_data = {"github_profile_url": "http://www.github.com/kaw393939"}
+async def test_update_user_github(async_client, test_user, admin_token, db_session):
+    unique_email = f"{datetime.now().timestamp()}_{test_user.email}"
+    updated_data = {"email": unique_email, "github_profile_url": "http://www.github.com/kaw393939", "nickname": "UpdatedNickname"}
     headers = {"Authorization": f"Bearer {admin_token}"}
-    response = await async_client.put(f"/users/{admin_user.id}", json=updated_data, headers=headers)
-    assert response.status_code == 200
-    assert response.json()["github_profile_url"] == updated_data["github_profile_url"]
+    pre_update = await async_client.get(f"/users/{test_user.id}", headers=headers)
+    print("Pre-Update User Data:", pre_update.json())
+
+    result = await db_session.execute(sa.select(User).where(User.id == test_user.id))
+    db_user = result.scalars().first()
+    if db_user:
+        print("Database User Check: User found")
+    else:
+        print("Database User Check: User NOT found")
+
+    response = await async_client.put(f"/users/{test_user.id}", json=updated_data, headers=headers)
+    print("Update Response:", response.json())
+
+    assert response.status_code == 200, f"Expected 200 OK, got {response.status_code} with message {response.text}"
+
+    post_update = await async_client.get(f"/users/{test_user.id}", headers=headers)
+    print("Post-Update User Data:", post_update.json())
+
 
 @pytest.mark.asyncio
 async def test_update_user_linkedin(async_client, admin_user, admin_token):
-    updated_data = {"linkedin_profile_url": "http://www.linkedin.com/kaw393939"}
+    unique_email = f"{datetime.now().timestamp()}_{admin_user.email}"
+    updated_data = {"email": unique_email, "linkedin_profile_url": "http://www.linkedin.com/kaw393939", "nickname": "UpdatedNickname"}
     headers = {"Authorization": f"Bearer {admin_token}"}
     response = await async_client.put(f"/users/{admin_user.id}", json=updated_data, headers=headers)
     assert response.status_code == 200

--- a/tests/test_services/test_user_service.py
+++ b/tests/test_services/test_user_service.py
@@ -64,7 +64,7 @@ async def test_get_by_email_user_does_not_exist(db_session):
 # Test updating a user with valid data
 async def test_update_user_valid_data(db_session, user):
     new_email = "updated_email@example.com"
-    updated_user = await UserService.update(db_session, user.id, {"email": new_email})
+    updated_user = await UserService.update(db_session, user.id, {"email": new_email, "nickname": "new_nickname"})
     assert updated_user is not None
     assert updated_user.email == new_email
 


### PR DESCRIPTION
Fixes #7 

Added a uniqueness check for email and nickname during the update process to ensure they do not conflict with existing users.