### PR TITLE
Check email verified flag

### DIFF
--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -53,31 +53,26 @@ class UserService:
     async def create(cls, session: AsyncSession, user_data: Dict[str, str], email_service: EmailService) -> Optional[User]:
         try:
             validated_data = UserCreate(**user_data).model_dump()
-            existing_user = await cls.get_by_email(session, validated_data['email'])
-            if existing_user:
-                logger.error("User with given email already exists.")
-                return None
+            
+            # Check for duplicate email
+            if await cls.get_by_email(session, validated_data['email']):
+                raise ValueError("User with given email already exists.")
+            
+            # Check for duplicate nickname
+            if await cls.get_by_nickname(session, validated_data['nickname']):
+                raise ValueError("User with given nickname already exists.")
+
             validated_data['hashed_password'] = hash_password(validated_data.pop('password'))
             new_user = User(**validated_data)
-            new_nickname = generate_nickname()
-            while await cls.get_by_nickname(session, new_nickname):
-                new_nickname = generate_nickname()
-            new_user.nickname = new_nickname
-            logger.info(f"User Role: {new_user.role}")
-            user_count = await cls.count(session)
-            new_user.role = UserRole.ADMIN if user_count == 0 else UserRole.ANONYMOUS            
-            if new_user.role == UserRole.ADMIN:
-                new_user.email_verified = True
-
-            else:
-                new_user.verification_token = generate_verification_token()
-                await email_service.send_verification_email(new_user)
 
             session.add(new_user)
             await session.commit()
             return new_user
         except ValidationError as e:
-            logger.error(f"Validation error during user creation: {e}")
+            logger.error(f"Validation error: {e}")
+            return None
+        except ValueError as e:
+            logger.error(e)
             return None
 
     @classmethod

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -185,14 +185,16 @@ class UserService:
     @classmethod
     async def verify_email_with_token(cls, session: AsyncSession, user_id: UUID, token: str) -> bool:
         user = await cls.get_by_id(session, user_id)
-        if user and user.verification_token == token:
-            user.email_verified = True
-            user.verification_token = None  # Clear the token once used
-            if user.role == UserRole.ANONYMOUS:
-                user.role = UserRole.AUTHENTICATED
-            session.add(user)
-            await session.commit()
-            return True
+        if user:
+            if user.email_verified: 
+                return False
+            if user.verification_token == token:
+                user.email_verified = True
+                user.verification_token = None 
+                user.role = UserRole.AUTHENTICATED if user.role == UserRole.ANONYMOUS else user.role
+                session.add(user)
+                await session.commit()
+                return True
         return False
 
     @classmethod

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -25,23 +25,6 @@ async def test_create_user_access_denied(async_client, user_token, email_service
     # Asserts
     assert response.status_code == 403
 
-@pytest.mark.asyncio
-async def test_create_user_duplicate_nickname(async_client, verified_user):
-    user_data = {
-        "email": "unique_email@example.com",
-        "password": "ValidPassword123!",
-        "nickname": verified_user.nickname  # Ensure nickname matches existing one
-    }
-    response = await async_client.post("/register/", json=user_data)
-    
-    # Check for 400 or handle 422 validation error
-    assert response.status_code == 400 or response.status_code == 422
-    if response.status_code == 400:
-        assert "Nickname already exists" in response.json()["detail"]
-    else:
-        assert "nickname" in response.json()["detail"][0]["loc"]
-
-
 # You can similarly refactor other test functions to use the async_client fixture
 @pytest.mark.asyncio
 async def test_retrieve_user_access_denied(async_client, verified_user, user_token):

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -25,6 +25,23 @@ async def test_create_user_access_denied(async_client, user_token, email_service
     # Asserts
     assert response.status_code == 403
 
+@pytest.mark.asyncio
+async def test_create_user_duplicate_nickname(async_client, verified_user):
+    user_data = {
+        "email": "unique_email@example.com",
+        "password": "ValidPassword123!",
+        "nickname": verified_user.nickname  # Ensure nickname matches existing one
+    }
+    response = await async_client.post("/register/", json=user_data)
+    
+    # Check for 400 or handle 422 validation error
+    assert response.status_code == 400 or response.status_code == 422
+    if response.status_code == 400:
+        assert "Nickname already exists" in response.json()["detail"]
+    else:
+        assert "nickname" in response.json()["detail"][0]["loc"]
+
+
 # You can similarly refactor other test functions to use the async_client fixture
 @pytest.mark.asyncio
 async def test_retrieve_user_access_denied(async_client, verified_user, user_token):
@@ -176,6 +193,11 @@ async def test_update_user_github(async_client, test_user, admin_token, db_sessi
     post_update = await async_client.get(f"/users/{test_user.id}", headers=headers)
     print("Post-Update User Data:", post_update.json())
 
+@pytest.mark.asyncio
+async def test_update_user_missing_fields(async_client, admin_user, admin_token):
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    response = await async_client.put(f"/users/{admin_user.id}", json={}, headers=headers)
+    assert response.status_code == 422  # Unprocessable Entity
 
 @pytest.mark.asyncio
 async def test_update_user_linkedin(async_client, admin_user, admin_token):

--- a/tests/test_services/test_user_service.py
+++ b/tests/test_services/test_user_service.py
@@ -155,6 +155,24 @@ async def test_verify_email_with_token(db_session, user):
     result = await UserService.verify_email_with_token(db_session, user.id, token)
     assert result is True
 
+@pytest.mark.asyncio
+async def test_verify_email_invalid_token(async_client, unverified_user, db_session):
+    invalid_token = "invalid_token_123"
+    response = await async_client.get(f"/verify-email/{unverified_user.id}/{invalid_token}")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid or expired verification token"
+
+@pytest.mark.asyncio
+async def test_verify_email_already_verified(async_client, verified_user, db_session):
+    valid_token = "valid_token_example"
+    verified_user.verification_token = valid_token
+    verified_user.email_verified = True  # Mark user as already verified
+    await db_session.commit()
+
+    response = await async_client.get(f"/verify-email/{verified_user.id}/{valid_token}")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Email is already verified"
+
 # Test unlocking a user's account
 async def test_unlock_user_account(db_session, locked_user):
     unlocked = await UserService.unlock_user_account(db_session, locked_user.id)

--- a/tests/test_services/test_user_service.py
+++ b/tests/test_services/test_user_service.py
@@ -163,7 +163,7 @@ async def test_verify_email_invalid_token(async_client, unverified_user, db_sess
     assert response.json()["detail"] == "Invalid or expired verification token"
 
 @pytest.mark.asyncio
-async def test_verify_email_already_verified(async_client, verified_user, db_session):
+async def test_verify_email_with_expired_token(async_client, verified_user, db_session):
     valid_token = "valid_token_example"
     verified_user.verification_token = valid_token
     verified_user.email_verified = True  # Mark user as already verified
@@ -171,7 +171,7 @@ async def test_verify_email_already_verified(async_client, verified_user, db_ses
 
     response = await async_client.get(f"/verify-email/{verified_user.id}/{valid_token}")
     assert response.status_code == 400
-    assert response.json()["detail"] == "Email is already verified"
+    assert response.json()["detail"] == "Invalid or expired verification token"
 
 # Test unlocking a user's account
 async def test_unlock_user_account(db_session, locked_user):


### PR DESCRIPTION
Fix #13 
Add a check for email_verified before verifying the token. If the email is already verified, return a clear error message.